### PR TITLE
Fix JDK-1.8 build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,17 +7,18 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
+        java: [1.8, 11, 13]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
       - name: Build it with Maven
         run: mvn -B verify -Pqulice

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target/
 .idea/
 *.iml
 .DS_Store
+.classpath
+.project
+.settings/**

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,8 @@ SOFTWARE.
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>0.2.1</version>
+    <version>0.3</version>
   </parent>
-  <groupId>com.artipie</groupId>
   <artifactId>files-adapter</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -80,12 +79,12 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.5</version>
+      <version>0.6.1</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.14.5</version>
+      <version>0.15</version>
     </dependency>
     <!-- Test only dependencies -->
     <dependency>

--- a/src/test/java/com/artipie/files/FileSliceITCase.java
+++ b/src/test/java/com/artipie/files/FileSliceITCase.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
@@ -137,7 +138,7 @@ public class FileSliceITCase {
         MatcherAssert.assertThat(
             new String(
                 Files.readAllBytes(
-                    Path.of(temp.toString(), hellot)
+                    Paths.get(temp.toString(), hellot)
                 )
             ), new IsEqual<>(hello)
         );
@@ -178,7 +179,7 @@ public class FileSliceITCase {
         MatcherAssert.assertThat(
             new String(
                 Files.readAllBytes(
-                    Path.of(temp.toString(), hellot)
+                    Paths.get(temp.toString(), hellot)
                 )
             ), new IsEqual<>(hello)
         );


### PR DESCRIPTION
#9 - updated parent pom and asto deps, using 1.8 API of nio, added CI builds with java matrix 1.8, 11, 13 versions