### PR TITLE
Added cache to proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>0.4.2</version>
+    <version>0.5.1</version>
   </parent>
   <artifactId>files-adapter</artifactId>
   <version>1.0-SNAPSHOT</version>
@@ -84,7 +84,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.33.6</version>
+      <version>0.35</version>
     </dependency>
     <!-- Test only dependencies -->
     <dependency>
@@ -123,12 +123,12 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.17.7</version>
+      <version>0.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http-client</artifactId>
-      <version>0.3</version>
+      <version>0.3.5</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/com/artipie/files/FileProxySlice.java
+++ b/src/main/java/com/artipie/files/FileProxySlice.java
@@ -24,21 +24,38 @@
 package com.artipie.files;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.Storage;
+import com.artipie.asto.cache.Cache;
+import com.artipie.asto.cache.CacheControl;
+import com.artipie.asto.cache.FromRemoteCache;
+import com.artipie.asto.cache.Remote;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.client.ClientSlices;
 import com.artipie.http.client.UriClientSlice;
 import com.artipie.http.client.auth.AuthClientSlice;
 import com.artipie.http.client.auth.Authenticator;
+import com.artipie.http.rq.RequestLineFrom;
+import com.artipie.http.rs.RsFull;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.slice.KeyFromPath;
+import io.reactivex.Flowable;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import org.reactivestreams.Publisher;
 
 /**
  * Binary files proxy {@link Slice} implementation.
  * @since 0.4
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class FileProxySlice implements Slice {
 
@@ -48,12 +65,17 @@ public final class FileProxySlice implements Slice {
     private final Slice remote;
 
     /**
+     * Cache.
+     */
+    private final Cache cache;
+
+    /**
      * New files proxy slice.
      * @param clients HTTP clients
      * @param remote Remote URI
      */
     public FileProxySlice(final ClientSlices clients, final URI remote) {
-        this(new UriClientSlice(clients, remote));
+        this(new UriClientSlice(clients, remote), Cache.NOP);
     }
 
     /**
@@ -61,25 +83,73 @@ public final class FileProxySlice implements Slice {
      * @param clients HTTP clients
      * @param remote Remote URI
      * @param auth Authenticator
+     * @param asto Cache storage
+     * @checkstyle ParameterNumberCheck (500 lines)
      */
-    public FileProxySlice(final ClientSlices clients, final URI remote, final Authenticator auth) {
-        this(new AuthClientSlice(new UriClientSlice(clients, remote), auth));
+    public FileProxySlice(final ClientSlices clients, final URI remote,
+        final Authenticator auth, final Storage asto) {
+        this(
+            new AuthClientSlice(new UriClientSlice(clients, remote), auth),
+            new FromRemoteCache(asto)
+        );
     }
 
     /**
      * Ctor.
      *
      * @param remote Remote slice
+     * @param cache Cache
      */
-    private FileProxySlice(final Slice remote) {
+    FileProxySlice(final Slice remote, final Cache cache) {
         this.remote = remote;
+        this.cache = cache;
     }
 
     @Override
     public Response response(
-        final String line, final Iterable<Map.Entry<String, String>> headers,
-        final Publisher<ByteBuffer> body
+        final String line, final Iterable<Map.Entry<String, String>> ignored,
+        final Publisher<ByteBuffer> pub
     ) {
-        return this.remote.response(line, Headers.EMPTY, Content.EMPTY);
+        final AtomicReference<Headers> headers = new AtomicReference<>();
+        return new AsyncResponse(
+            this.cache.load(
+                new KeyFromPath(new RequestLineFrom(line).uri().getPath()),
+                new Remote.WithErrorHandling(
+                    () -> {
+                        final CompletableFuture<Optional<? extends Content>> promise =
+                            new CompletableFuture<>();
+                        this.remote.response(line, Headers.EMPTY, Content.EMPTY).send(
+                            (rsstatus, rsheaders, rsbody) -> {
+                                final CompletableFuture<Void> term = new CompletableFuture<>();
+                                headers.set(rsheaders);
+                                if (rsstatus.success()) {
+                                    final Flowable<ByteBuffer> body = Flowable.fromPublisher(rsbody)
+                                        .doOnError(term::completeExceptionally)
+                                        .doOnTerminate(() -> term.complete(null));
+                                    promise.complete(Optional.of(new Content.From(body)));
+                                } else {
+                                    promise.complete(Optional.empty());
+                                }
+                                return term;
+                            }
+                        );
+                        return promise;
+                    }
+                ),
+                CacheControl.Standard.ALWAYS
+            ).handle(
+                (content, throwable) -> {
+                    final CompletableFuture<Response> result = new CompletableFuture<>();
+                    if (throwable == null && content.isPresent()) {
+                        result.complete(
+                            new RsFull(RsStatus.OK, new Headers.From(headers.get()), content.get())
+                        );
+                    } else {
+                        result.complete(new RsWithStatus(RsStatus.NOT_FOUND));
+                    }
+                    return result;
+                }
+            ).thenCompose(Function.identity())
+        );
     }
 }

--- a/src/test/java/com/artipie/files/FileProxySliceAuthIT.java
+++ b/src/test/java/com/artipie/files/FileProxySliceAuthIT.java
@@ -30,7 +30,7 @@ import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.Headers;
 import com.artipie.http.Slice;
 import com.artipie.http.auth.Authentication;
-import com.artipie.http.client.auth.GenericAuthenticator;
+import com.artipie.http.client.auth.BasicAuthenticator;
 import com.artipie.http.client.jetty.JettyClientSlices;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
@@ -96,7 +96,8 @@ final class FileProxySliceAuthIT {
             new FileProxySlice(
                 this.client,
                 URI.create(String.format("http://localhost:%d", port)),
-                new GenericAuthenticator(username, password)
+                new BasicAuthenticator(username, password),
+                new InMemoryStorage()
             )
         );
     }

--- a/src/test/java/com/artipie/files/FileProxySliceTest.java
+++ b/src/test/java/com/artipie/files/FileProxySliceTest.java
@@ -179,7 +179,7 @@ final class FileProxySliceTest {
     @Test
     void returnsNotFoundWhenRemoteReturnedBadRequest() {
         MatcherAssert.assertThat(
-            "Incorrect status, 400 is expected",
+            "Incorrect status, 404 is expected",
             new FileProxySlice(
                 new SliceSimple(new RsWithStatus(RsStatus.BAD_REQUEST)),
                 new FromRemoteCache(this.storage)
@@ -190,7 +190,7 @@ final class FileProxySliceTest {
             )
         );
         MatcherAssert.assertThat(
-            "Cache storage should be empty",
+            "Cache storage is not empty",
             this.storage.list(Key.ROOT).join().isEmpty(),
             new IsEqual<>(true)
         );

--- a/src/test/java/com/artipie/files/FileProxySliceTest.java
+++ b/src/test/java/com/artipie/files/FileProxySliceTest.java
@@ -24,21 +24,37 @@
 package com.artipie.files;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.blocking.BlockingStorage;
+import com.artipie.asto.cache.FromRemoteCache;
 import com.artipie.asto.ext.PublisherAs;
+import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.Headers;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.client.ClientSlices;
+import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.hm.RsHasHeaders;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.hm.SliceHasResponse;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsFull;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.rs.StandardRs;
+import com.artipie.http.slice.SliceSimple;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
+import org.cactoos.map.MapEntry;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -47,7 +63,18 @@ import org.junit.jupiter.api.Test;
  * @since 0.7
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class FileProxySliceTest {
+
+    /**
+     * Test storage.
+     */
+    private Storage storage;
+
+    @BeforeEach
+    void init() {
+        this.storage = new InMemoryStorage();
+    }
 
     @Test
     void sendEmptyHeadersAndContent() throws Exception {
@@ -85,6 +112,87 @@ final class FileProxySliceTest {
             "Body is empty",
             body.get(),
             new IsEqual<>(new byte[0])
+        );
+    }
+
+    @Test
+    void getsContentFromRemoteAndAdsItToCache() {
+        final byte[] body = "some".getBytes();
+        final String key = "any";
+        MatcherAssert.assertThat(
+            "Should returns body from remote",
+            new FileProxySlice(
+                new SliceSimple(
+                    new RsFull(
+                        RsStatus.OK, new Headers.From("header", "value"), new Content.From(body)
+                    )
+                ),
+                new FromRemoteCache(this.storage)
+            ),
+            new SliceHasResponse(
+                Matchers.allOf(
+                    new RsHasBody(body),
+                    new RsHasHeaders(
+                        new MapEntry<>("header", "value"),
+                        new MapEntry<>("Content-Length", "4"),
+                        new MapEntry<>("Content-Length", "4")
+                    )
+                ),
+                new RequestLine(RqMethod.GET, String.format("/%s", key))
+            )
+        );
+        MatcherAssert.assertThat(
+            "Does not store data in cache",
+            new BlockingStorage(this.storage).value(new Key.From(key)),
+            new IsEqual<>(body)
+        );
+    }
+
+    @Test
+    void getsFromCacheOnError() {
+        final byte[] body = "abc123".getBytes();
+        final String key = "any";
+        this.storage.save(new Key.From(key), new Content.From(body)).join();
+        MatcherAssert.assertThat(
+            "Does not return body from cache",
+            new FileProxySlice(
+                new SliceSimple(new RsWithStatus(RsStatus.INTERNAL_ERROR)),
+                new FromRemoteCache(this.storage)
+            ),
+            new SliceHasResponse(
+                Matchers.allOf(
+                    new RsHasStatus(RsStatus.OK), new RsHasBody(body),
+                    new RsHasHeaders(
+                        new MapEntry<>("Content-Length", String.valueOf(body.length))
+                    )
+                ),
+                new RequestLine(RqMethod.GET, String.format("/%s", key))
+            )
+        );
+        MatcherAssert.assertThat(
+            "Data should stays intact in cache",
+            new BlockingStorage(this.storage).value(new Key.From(key)),
+            new IsEqual<>(body)
+        );
+    }
+
+    @Test
+    void returnsNotFoundWhenRemoteReturnedBadRequest() {
+        MatcherAssert.assertThat(
+            "Incorrect status, 400 is expected",
+            new FileProxySlice(
+                new SliceSimple(new RsWithStatus(RsStatus.BAD_REQUEST)),
+                new FromRemoteCache(this.storage)
+            ),
+            new SliceHasResponse(
+                new RsHasStatus(RsStatus.NOT_FOUND),
+                new RequestLine(RqMethod.GET, "/any")
+            )
+        );
+        MatcherAssert.assertThat(
+            "Cache storage should be empty",
+            this.storage.list(Key.ROOT).join().isEmpty(),
+            new IsEqual<>(true)
         );
     }
 


### PR DESCRIPTION
Part of #43 
Added cache to proxy: item is obtained from remote and cached, if remote does not respond with success, item is loaded from cache.

Created https://github.com/artipie/http/issues/305 to fix `RsWithBody`